### PR TITLE
spec-path-fix

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -11,7 +11,7 @@ module.exports = (grunt) ->
     # javascript sources
     js_dir: 'js'
     js_src: 'js/**/*.js'
-    js_specs: 'js/test/**/*.js'
+    js_specs: 'js/test/**/*.spec.js'
 
     # build directory
     build_dir: 'build'


### PR DESCRIPTION
The spec path pattern should include `.spec` in case other files (e.g. testing utils) are included in the `test/` directory.
